### PR TITLE
Remove legacy code from app metadata

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,13 +12,11 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/weather/master/screenshots/2.png</screenshot>
     <dependencies>
         <php min-version="5.6" min-int-size="32"/>
-        <owncloud min-version="8.1" max-version="9.2" />
-        <nextcloud min-version="10" max-version="13" />
+        <nextcloud min-version="11" max-version="13"/>
     </dependencies>
     <website>https://github.com/nextcloud/weather</website>
     <bugs>https://github.com/nextcloud/weather/issues</bugs>
     <repository type="git">https://github.com/nextcloud/weather</repository>
-    <ocsid>170605</ocsid>
     <namespace>Weather</namespace>
     <settings>
         <admin>OCA\Weather\Settings\AdminSettings</admin>


### PR DESCRIPTION
- apps.owncloud.com is not longer working = you can not install this app via ownCloud AppStore (was needed for Nextcloud <=10
- ocsid not longer needed
- Nextcloud 11< is compatible and tested