### PR TITLE
Add complete translation of PHP code and more forecast data

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,10 +35,14 @@ class Application extends App {
 		$container->registerService('UserId', function(IContainer $c) {
 			$user = $c->getServer()->getUserSession()->getUser();
 			return $user ? $user->getUID() : null;
-                });
+    });
 
 		$container->registerService('Config', function($c) {
 			return $c->query('ServerContainer')->getConfig();
+		});
+
+		$container->registerService('L10N', function($c) {
+		return $c->query('ServerContainer')->getL10N($c->query('AppName'));
 		});
 
 		/**
@@ -84,7 +88,8 @@ class Application extends App {
 				$c->query('Request'),
 				$c->query('UserId'),
 				$c->query('CityMapper'),
-				$c->query('SettingsMapper')
+				$c->query('SettingsMapper'),
+				$c->query('L10N')
 			);
 		});
 	}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,10 +32,9 @@ class Application extends App {
 		/**
 		 * Core
 		 */
-		
 		$container->registerService('UserId', function(IContainer $c) {
-                	$user = $c->getServer()->getUserSession()->getUser();
-               		return $user ? $user->getUID() : null;
+			$user = $c->getServer()->getUserSession()->getUser();
+			return $user ? $user->getUID() : null;
                 });
 
 		$container->registerService('Config', function($c) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,10 +32,6 @@ class Application extends App {
 		/**
 		 * Core
 		 */
-		$container->registerService('UserId', function(IContainer $c) {
-			return \OC::$server->getUserSession()->getUser()->getUID();
-		});
-
 		$container->registerService('Config', function($c) {
 			return $c->query('ServerContainer')->getConfig();
 		});

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,12 @@ class Application extends App {
 		/**
 		 * Core
 		 */
+		
+		$container->registerService('UserId', function(IContainer $c) {
+                	$user = $c->getServer()->getUserSession()->getUser();
+               		return $user ? $user->getUID() : null;
+                });
+
 		$container->registerService('Config', function($c) {
 			return $c->query('ServerContainer')->getConfig();
 		});

--- a/lib/Controller/WeatherController.php
+++ b/lib/Controller/WeatherController.php
@@ -65,7 +65,7 @@ class WeatherController extends IntermediateController {
 		$currentLang = \OC::$server->getL10N('core')->getLanguageCode();
 
 		if (preg_match("/_/i", $currentLang)) {
-		$currentLang = strstr($currentLang, '_', true);
+			$currentLang = strstr($currentLang, '_', true);
 		}
 
 		if (in_array($currentLang, $openWeatherMapLang)) {

--- a/lib/Controller/WeatherController.php
+++ b/lib/Controller/WeatherController.php
@@ -34,6 +34,7 @@ class WeatherController extends IntermediateController {
 	private static $apiWeatherURL = "http://api.openweathermap.org/data/2.5/weather?mode=json&q=";
 	private static $apiForecastURL = "http://api.openweathermap.org/data/2.5/forecast?mode=json&q=";
 
+	public function __construct ($appName, IConfig $config, IRequest $request, $userId, CityMapper $mapper, SettingsMapper $settingsMapper) {
 		parent::__construct($appName, $request);
 		$this->userId = $userId;
 		$this->mapper = $mapper;
@@ -114,6 +115,7 @@ class WeatherController extends IntermediateController {
 	private function windDegToString($deg): string {
 		if ($deg > 0 && $deg < 23 ||
 			$deg > 333) {
+			return "North";
 		}
 		else if ($deg > 22 && $deg < 67) {
 			return "North-East";

--- a/lib/Controller/WeatherController.php
+++ b/lib/Controller/WeatherController.php
@@ -112,7 +112,7 @@ class WeatherController extends IntermediateController {
 		return $cityDatas;
 	}
 
-	private function windDegToString($deg): string {
+	private static function windDegToString($deg): string {
 		if ($deg > 0 && $deg < 23 ||
 			$deg > 333) {
 			return "North";

--- a/lib/Controller/WeatherController.php
+++ b/lib/Controller/WeatherController.php
@@ -65,15 +65,15 @@ class WeatherController extends IntermediateController {
 		$currentLang = \OC::$server->getL10N('core')->getLanguageCode();
 
 		if (preg_match("/_/i", $currentLang)) {
-	  $nccurrentLANG = strstr($currentLang, '_', true);
-    }
+		$currentLang = strstr($currentLang, '_', true);
+		}
 
 		if (in_array($currentLang, $openWeatherMapLang)) {
-		  $reqContent = $this->curlGET(WeatherController::$apiWeatherURL.$name."&APPID=".$apiKey."&units=".$this->metric."&lang=".$currentLang);
+			$reqContent = $this->curlGET(WeatherController::$apiWeatherURL.$name."&APPID=".$apiKey."&units=".$this->metric."&lang=".$currentLang);
 		}
-    else {
+		else {
 			$reqContent = $this->curlGET(WeatherController::$apiWeatherURL.$name."&APPID=".$apiKey."&units=".$this->metric);
-	  }
+		}
 
 		if ($reqContent[0] != Http::STATUS_OK) {
 			$this->errorCode = $reqContent[0];
@@ -84,7 +84,7 @@ class WeatherController extends IntermediateController {
 		$cityDatas["forecast"] = array();
 
 		if (in_array($currentLang, $openWeatherMapLang)) {
-		  $forecast = json_decode(file_get_contents(WeatherController::$apiForecastURL.$name."&APPID=".$apiKey."&units=".$this->metric."&lang=".$currentLang), true);
+			$forecast = json_decode(file_get_contents(WeatherController::$apiForecastURL.$name."&APPID=".$apiKey."&units=".$this->metric."&lang=".$currentLang), true);
 		}
 		else {
 			$forecast = json_decode(file_get_contents(WeatherController::$apiForecastURL.$name."&APPID=".$apiKey."&units=".$this->metric), true);

--- a/templates/main.php
+++ b/templates/main.php
@@ -63,14 +63,14 @@
 		<div id="city-forecast-panel">
 			<table>
 				<tr>
-					<th><?php p($l->t('Hour')); ?></th>
+					<th><?php p($l->t('Date')); ?></th>
 					<th><?php p($l->t('Temperature')); ?></th>
 					<th><?php p($l->t('Weather')); ?></th>
 					<th><?php p($l->t('Pressure')); ?></th>
 					<th><?php p($l->t('Wind')); ?></th>
 				</tr>
 				<tr ng-repeat="forecast in currentCity.forecast">
-					<td>{{ forecast.hour * 1000 | date:'HH:mm'}}</td>
+					<td>{{ forecast.date }}</td>
 					<td>{{ forecast.temperature }}{{ metricRepresentation }}</td>
 					<td>{{ forecast.weather }}</td>
 					<td>{{ forecast.pressure }}</td>


### PR DESCRIPTION
This is a second PR that completes the translation of the Weather app. It add a check for the current language set by the user and requests a translated dataset from the Openweathermap API. Additionally, it also translates the wind directions. 

Together with https://github.com/nextcloud/weather/pull/72 this should solve https://github.com/nextcloud/weather/issues/60 completely.