### PR TITLE
fix #75 in upstream

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,11 @@
 #city-list-left {
+	display: flex;
+	flex-direction: column;
 	width: 250px;
 	height: 100%;
 	float: left;
 	-moz-box-sizing: border-box; box-sizing: border-box;
 	background-color: #fff;
-	padding-bottom: 44px;
 	border-left: 1px solid #ddd;
 	border-right: 1px solid #ddd;
 	-webkit-user-select: none;
@@ -60,9 +61,8 @@
 
 #city-right {
 	padding: 45px;
-	height: 100%;
-	overflow-y: hidden;
-	overflow-x: auto;
+	height: calc(100vh - 50px); /* substract header */
+	overflow: auto;
 	top: 0;
 	bottom: 0;
 	right: 0;


### PR DESCRIPTION
#75 was caused by the long forecast table in the right pane, which pushed the Settings button off-screen.
This PR maximizes both left and right panes' height to the total available height: left pane using flexbox, right pane by calculation from viewport height and the header height.

It also allows vertical scrollbar in the right pane so that the entire content can be viewed.