### PR TITLE
Update responsive view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -219,8 +219,52 @@
 }
 }
 
+/* tablets */
+@media (max-width: 1000px) {
+	#city-right {
+		padding: 0;
+	}
+	#city-forecast-panel {
+		float: none;
+		width: 100%;
+	}
+}
+@media (max-width: 900px) {
+	#city-right {
+		padding: 0;
+	}
+	#city-forecast-panel {
+		float: none;
+		width: 100%;
+	}
+}
+
+/* breakpoints for horizontal city list and the forecast table */
+@media screen and (max-width: 850px) and (min-width: 600px) {
+	#city-list-left ul.city-list li {
+		min-width: 33%;
+	}
+}
+@media screen and (max-width: 600px) and (min-width: 350px) {
+	#city-list-left ul.city-list li {
+		min-width: 50%;
+	}
+
+	#city-right tr td:nth-of-type(n+4), th:nth-of-type(n+4) {
+		display: none;
+	}
+}
+@media screen and (max-width: 350px) {
+	#city-list-left ul.city-list li {
+		min-width: 100%;
+	}
+	#city-right tr td:nth-of-type(n+5), th:nth-of-type(n+5) {
+		display: none;
+	}
+}
+
 /* smartphones */
-@media screen and (orientation: portrait) and (max-width: 12cm) and (min-height: 10cm) {
+@media screen and (max-width: 850px) and (min-height: 10cm) {
 	#app {
 		display: flex;
 		flex-direction: column;
@@ -237,19 +281,14 @@
 	}
 	#city-list-left ul.city-list li {
 		flex: min-content;
-		min-width: 50%;
 	}
 	#city-list-left ul.city-list li:last-child {
 		flex: auto;
-		min-width: 100%;
 	}
 	#city-right {
 		display: flex;
 		flex-direction: column;
 		padding: 0;
-	}
-	#city-right tr td:nth-of-type(n+4), th:nth-of-type(n+4) {
-		display: none;
 	}
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -219,6 +219,41 @@
 }
 }
 
+/* smartphones */
+@media screen and (orientation: portrait) and (max-width: 12cm) and (min-height: 10cm) {
+	#app {
+		display: flex;
+		flex-direction: column;
+		height: calc(100vh - 50px);
+	}
+	#city-list-left {
+		order: 2;
+		width: 100%;
+		flex: min-content;
+	}
+	#city-list-left ul.city-list {
+		flex-direction: row;
+		display: flex;
+		flex-wrap: wrap;
+	}
+	#city-list-left ul.city-list li {
+		flex: min-content;
+		min-width: 50%;
+	}
+	#city-list-left ul.city-list li:last-child {
+		flex: auto;
+		min-width: 100%;
+	}
+	#city-right {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+	}
+	#city-right tr td:nth-of-type(n+4), th:nth-of-type(n+4) {
+		display: none;
+	}
+}
+
 #app {
 	width: 100%;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -234,7 +234,6 @@
 	#city-list-left ul.city-list {
 		flex-direction: row;
 		display: flex;
-		flex-wrap: wrap;
 	}
 	#city-list-left ul.city-list li {
 		flex: min-content;


### PR DESCRIPTION
Moving discussion here from #34 (Smartphone view).

Current status:
-   city list is on the bottom, horizontally scrollable (by removing `        flex-wrap: wrap;`)
    -    this solves the issue of longer city lists blocking the useful content as per
-   add city item has 100% width, but it looks odd when it is only partially visible, and the form is open (screenshot below).
    -    how about hiding "Add city" altogether?
    -    we may be out of luck with pure CSS: as it is in the same `LI` as the cities, I not sure we can wrap it into the next row.
-   tablet mode still not addressed

![pngout-fs8-nq8](https://user-images.githubusercontent.com/134611/71767987-647c3580-2f12-11ea-9fd0-16078e652cf3.png)


